### PR TITLE
Fix relative path and footer issues in Papers section

### DIFF
--- a/site/papers/build/generate-papers.js
+++ b/site/papers/build/generate-papers.js
@@ -55,11 +55,11 @@ const individualTemplate = (paper, paperSlug) => `
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     
     <!-- CSS -->
-    <link rel="stylesheet" href="../../../assets/css/styles.css">
-    <link rel="stylesheet" href="../../../assets/css/papers.css">
+    <link rel="stylesheet" href="../../assets/css/styles.css">
+    <link rel="stylesheet" href="../../assets/css/papers.css">
     
     <!-- Favicon -->
-    <link rel="icon" type="image/svg+xml" href="../../../assets/img/logo.svg">
+    <link rel="icon" type="image/svg+xml" href="../../assets/img/logo.svg">
     
     <style>
         .paper-header {
@@ -205,16 +205,16 @@ const individualTemplate = (paper, paperSlug) => `
         <div class="container">
             <div class="header__inner">
                 <!-- Logo -->
-                <a href="../../../index.html" class="logo">
-                    <img src="../../../assets/img/logo.svg" alt="Prospero logo" class="logo__image">
+                <a href="../../index.html" class="logo">
+                    <img src="../../assets/img/logo.svg" alt="Prospero logo" class="logo__image">
                     <span class="logo__text">Prospero</span>
                 </a>
                 
                 <!-- Desktop Navigation -->
                 <nav class="nav">
                     <ul class="nav__list">
-                        <li><a href="../../../index.html" class="nav__link">Home</a></li>
-                        <li><a href="../../../about.html" class="nav__link">About</a></li>
+                        <li><a href="../../index.html" class="nav__link">Home</a></li>
+                        <li><a href="../../about.html" class="nav__link">About</a></li>
                         <li><a href="../index.html" class="nav__link nav__link--active">Papers</a></li>
                         <li><a href="#" class="nav__link">Projects</a></li>
                         <li><a href="#" class="nav__link">Contact</a></li>
@@ -234,8 +234,8 @@ const individualTemplate = (paper, paperSlug) => `
     <!-- Mobile Navigation (hidden by default) -->
     <nav class="mobile-nav" aria-hidden="true">
         <ul class="mobile-nav__list">
-            <li><a href="../../../index.html" class="mobile-nav__link">Home</a></li>
-            <li><a href="../../../about.html" class="mobile-nav__link">About</a></li>
+            <li><a href="../../index.html" class="mobile-nav__link">Home</a></li>
+            <li><a href="../../about.html" class="mobile-nav__link">About</a></li>
             <li><a href="../index.html" class="mobile-nav__link mobile-nav__link--active">Papers</a></li>
             <li><a href="#" class="mobile-nav__link">Projects</a></li>
             <li><a href="#" class="mobile-nav__link">Contact</a></li>
@@ -286,23 +286,33 @@ const individualTemplate = (paper, paperSlug) => `
     <!-- Footer -->
     <footer class="footer">
         <div class="container">
-            <div class="footer__content">
-                <p class="footer__copyright">© Prospero</p>
-                <nav class="footer__nav">
-                    <a href="../../../about.html" class="footer__link">About</a>
-                    <span class="footer__separator">•</span>
-                    <a href="../index.html" class="footer__link">Papers</a>
-                    <span class="footer__separator">•</span>
-                    <a href="#" class="footer__link">Projects</a>
-                    <span class="footer__separator">•</span>
-                    <a href="#" class="footer__link">Contact</a>
-                </nav>
+            <div class="footer__social">
+                <a href="#" class="footer__social-link" target="_blank" rel="noopener noreferrer" aria-label="YouTube">
+                    <svg class="footer__social-icon" viewBox="0 0 24 24">
+                        <path d="M19.615 3.184c-3.604-.246-11.631-.245-15.23 0-3.897.266-4.356 2.62-4.385 8.816.029 6.185.484 8.549 4.385 8.816 3.6.245 11.626.246 15.23 0 3.897-.266 4.356-2.62 4.385-8.816-.029-6.185-.484-8.549-4.385-8.816zm-10.615 12.816v-8l8 3.993-8 4.007z"/>
+                    </svg>
+                </a>
+                <a href="#" class="footer__social-link" target="_blank" rel="noopener noreferrer" aria-label="X (Twitter)">
+                    <svg class="footer__social-icon" viewBox="0 0 24 24">
+                        <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
+                    </svg>
+                </a>
+                <a href="#" class="footer__social-link" target="_blank" rel="noopener noreferrer" aria-label="Rumble">
+                    <svg class="footer__social-icon" viewBox="0 0 24 24">
+                        <path d="M19.68 12.74c0 4.41-3.59 8-8 8s-8-3.59-8-8 3.59-8 8-8 8 3.59 8 8zm-8-6.4c-3.53 0-6.4 2.87-6.4 6.4s2.87 6.4 6.4 6.4 6.4-2.87 6.4-6.4-2.87-6.4-6.4-6.4zm3.6 6.4c0 1.99-1.61 3.6-3.6 3.6s-3.6-1.61-3.6-3.6 1.61-3.6 3.6-3.6 3.6 1.61 3.6 3.6z"/>
+                    </svg>
+                </a>
+                <a href="#" class="footer__social-link" target="_blank" rel="noopener noreferrer" aria-label="TikTok">
+                    <svg class="footer__social-icon" viewBox="0 0 24 24">
+                        <path d="M19.59 6.69a4.83 4.83 0 0 1-3.77-4.25V2h-3.45v13.67a2.89 2.89 0 0 1-5.2 1.74 2.89 2.89 0 0 1 2.31-4.64 2.93 2.93 0 0 1 .88.13V9.4a6.84 6.84 0 0 0-1-.05A6.33 6.33 0 0 0 5 20.1a6.34 6.34 0 0 0 10.86-4.43v-7a8.16 8.16 0 0 0 4.77 1.52v-3.4a4.85 4.85 0 0 1-1-.1z"/>
+                    </svg>
+                </a>
             </div>
         </div>
     </footer>
     
     <!-- JavaScript -->
-    <script src="../../../assets/js/app.js"></script>
+    <script src="../../assets/js/app.js"></script>
     <script>
         // Generate table of contents
         document.addEventListener('DOMContentLoaded', function() {

--- a/site/papers/index.html
+++ b/site/papers/index.html
@@ -299,17 +299,27 @@
     <!-- Footer -->
     <footer class="footer">
         <div class="container">
-            <div class="footer__content">
-                <p class="footer__copyright">© Prospero</p>
-                <nav class="footer__nav">
-                    <a href="../about.html" class="footer__link">About</a>
-                    <span class="footer__separator">•</span>
-                    <a href="index.html" class="footer__link">Papers</a>
-                    <span class="footer__separator">•</span>
-                    <a href="#" class="footer__link">Projects</a>
-                    <span class="footer__separator">•</span>
-                    <a href="#" class="footer__link">Contact</a>
-                </nav>
+            <div class="footer__social">
+                <a href="#" class="footer__social-link" target="_blank" rel="noopener noreferrer" aria-label="YouTube">
+                    <svg class="footer__social-icon" viewBox="0 0 24 24">
+                        <path d="M19.615 3.184c-3.604-.246-11.631-.245-15.23 0-3.897.266-4.356 2.62-4.385 8.816.029 6.185.484 8.549 4.385 8.816 3.6.245 11.626.246 15.23 0 3.897-.266 4.356-2.62 4.385-8.816-.029-6.185-.484-8.549-4.385-8.816zm-10.615 12.816v-8l8 3.993-8 4.007z"/>
+                    </svg>
+                </a>
+                <a href="#" class="footer__social-link" target="_blank" rel="noopener noreferrer" aria-label="X (Twitter)">
+                    <svg class="footer__social-icon" viewBox="0 0 24 24">
+                        <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
+                    </svg>
+                </a>
+                <a href="#" class="footer__social-link" target="_blank" rel="noopener noreferrer" aria-label="Rumble">
+                    <svg class="footer__social-icon" viewBox="0 0 24 24">
+                        <path d="M19.68 12.74c0 4.41-3.59 8-8 8s-8-3.59-8-8 3.59-8 8-8 8 3.59 8 8zm-8-6.4c-3.53 0-6.4 2.87-6.4 6.4s2.87 6.4 6.4 6.4 6.4-2.87 6.4-6.4-2.87-6.4-6.4-6.4zm3.6 6.4c0 1.99-1.61 3.6-3.6 3.6s-3.6-1.61-3.6-3.6 1.61-3.6 3.6-3.6 3.6 1.61 3.6 3.6z"/>
+                    </svg>
+                </a>
+                <a href="#" class="footer__social-link" target="_blank" rel="noopener noreferrer" aria-label="TikTok">
+                    <svg class="footer__social-icon" viewBox="0 0 24 24">
+                        <path d="M19.59 6.69a4.83 4.83 0 0 1-3.77-4.25V2h-3.45v13.67a2.89 2.89 0 0 1-5.2 1.74 2.89 2.89 0 0 1 2.31-4.64 2.93 2.93 0 0 1 .88.13V9.4a6.84 6.84 0 0 0-1-.05A6.33 6.33 0 0 0 5 20.1a6.34 6.34 0 0 0 10.86-4.43v-7a8.16 8.16 0 0 0 4.77 1.52v-3.4a4.85 4.85 0 0 1-1-.1z"/>
+                    </svg>
+                </a>
             </div>
         </div>
     </footer>


### PR DESCRIPTION
- Corrected relative paths in the paper generation script (`site/papers/build/generate-papers.js`) from `../../../` to `../../` to fix broken links on individual paper pages.
- Replaced the inconsistent footer in the paper generation script with the correct site-wide footer.
- Replaced the inconsistent footer in the papers index page (`site/papers/index.html`) with the correct site-wide footer.
- Regenerated the individual paper pages to apply the fixes.