### PR TITLE
Add markdownlint configuration and script

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,9 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD041": false,
+  "MD033": false,
+  "MD004": {
+    "style": "dash"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,9 @@
         "highlight.js": "^11.9.0",
         "markdown-it": "^13.0.1"
       },
-      "devDependencies": {}
+      "devDependencies": {
+        "markdownlint-cli": "^0.41.0"
+      }
     },
     "node_modules/argparse": {
       "version": "1.0.10",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "site/papers/build/generate-papers.js",
   "scripts": {
     "build:papers": "node site/papers/build/generate-papers.js",
-    "dev": "python -m http.server 8000"
+    "dev": "python -m http.server 8000",
+    "lint:md": "markdownlint \"site/papers/content/**/*.md\""
   },
   "dependencies": {
     "markdown-it": "^13.0.1",
@@ -13,8 +14,14 @@
     "highlight.js": "^11.9.0",
     "fs-extra": "^11.1.1"
   },
-  "devDependencies": {},
-  "keywords": ["static-site", "markdown", "papers"],
+  "devDependencies": {
+    "markdownlint-cli": "^0.41.0"
+  },
+  "keywords": [
+    "static-site",
+    "markdown",
+    "papers"
+  ],
   "author": "Prospero",
   "license": "MIT"
 }


### PR DESCRIPTION
## Summary
- add markdownlint-cli as a dev dependency and expose an npm script for markdown linting
- configure markdownlint defaults to match the project's preferred formatting rules

## Testing
- npm run lint:md *(fails: markdownlint executable unavailable because packages cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68daa974e2308330aa3b0cab50b50f97