### PR TITLE
Add Stylelint configuration and CSS lint script

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,3 @@
+# Ignore generated or third-party CSS bundles
+site/assets/css/vendor/**
+site/assets/css/dist/**

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,13 @@
+{
+  "extends": [
+    "stylelint-config-standard",
+    "stylelint-config-prettier"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "site/assets/css/**/*.css"
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "site/papers/build/generate-papers.js",
   "scripts": {
     "build:papers": "node site/papers/build/generate-papers.js",
-    "dev": "python -m http.server 8000"
+    "dev": "python -m http.server 8000",
+    "lint:css": "stylelint \"site/assets/css/**/*.css\""
   },
   "dependencies": {
     "markdown-it": "^13.0.1",
@@ -13,8 +14,16 @@
     "highlight.js": "^11.9.0",
     "fs-extra": "^11.1.1"
   },
-  "devDependencies": {},
-  "keywords": ["static-site", "markdown", "papers"],
+  "devDependencies": {
+    "stylelint": "^16.10.0",
+    "stylelint-config-prettier": "^9.0.5",
+    "stylelint-config-standard": "^35.0.0"
+  },
+  "keywords": [
+    "static-site",
+    "markdown",
+    "papers"
+  ],
   "author": "Prospero",
   "license": "MIT"
 }


### PR DESCRIPTION
## Summary
- add Stylelint tooling as dev dependencies and expose an npm script for linting CSS assets
- create a Stylelint configuration that extends the standard rules and Prettier compatibility for site CSS
- add ignore patterns for future generated or vendor CSS bundles

## Testing
- npm run lint:css *(fails: Stylelint package unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68daa97342148330b6d686c7a95f62d6