### PR TITLE
Add linting and formatting tooling

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,5 @@
+node_modules/
+site/papers/public/
+site/papers/public/**
+dist/
+build/

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,40 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    node: true,
+    es2021: true,
+  },
+  parserOptions: {
+    ecmaVersion: 2021,
+    sourceType: 'module',
+  },
+  plugins: ['import', 'promise'],
+  extends: [
+    'eslint:recommended',
+    'plugin:import/recommended',
+    'plugin:promise/recommended',
+    'prettier',
+  ],
+  settings: {
+    'import/resolver': {
+      node: {
+        extensions: ['.js'],
+      },
+    },
+  },
+  overrides: [
+    {
+      files: ['site/assets/js/**/*.js'],
+      env: {
+        browser: true,
+      },
+    },
+    {
+      files: ['site/papers/build/**/*.js'],
+      env: {
+        node: true,
+      },
+    },
+  ],
+};

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+node_modules/
+site/papers/public/
+site/papers/public/**
+dist/
+build/
+*.log

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "printWidth": 100,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "arrowParens": "always"
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "site/papers/build/generate-papers.js",
   "scripts": {
     "build:papers": "node site/papers/build/generate-papers.js",
-    "dev": "python -m http.server 8000"
+    "dev": "python -m http.server 8000",
+    "lint:js": "eslint site/assets/js site/papers/build",
+    "format": "prettier --write \"site/**/*.{js,json,md,html,css}\""
   },
   "dependencies": {
     "markdown-it": "^13.0.1",
@@ -13,7 +15,14 @@
     "highlight.js": "^11.9.0",
     "fs-extra": "^11.1.1"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-promise": "^6.1.1",
+    "prettier": "^3.3.2"
+  },
   "keywords": ["static-site", "markdown", "papers"],
   "author": "Prospero",
   "license": "MIT"


### PR DESCRIPTION
## Summary
- add eslint and prettier dev dependencies plus npm scripts for linting and formatting
- configure eslint for browser and node targets while ignoring generated outputs
- add prettier configuration and ignore rules for consistent formatting across source files

## Testing
- npm run lint:js *(fails: global ESLint 9 is used because dev dependencies could not be installed in this environment, which expects the new flat config format)*

------
https://chatgpt.com/codex/tasks/task_e_68daa9692a8c8330a02c4c0e26282c28